### PR TITLE
Fix the DB connection during unit tests

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,18 @@
 const http = require('http');
 const app = require('./main/app');
+const mongoose = require('mongoose');
+
+// TODO : change to use env var
+const connect = mongoose.connect('mongodb://localhost:27017/zikstock',
+    {
+        useNewUrlParser: true,
+        useUnifiedTopology: true,
+        useCreateIndex: true,
+        useFindAndModify: false
+    });
+connect.then(() => {
+    console.log("Connected to MongoDB");
+}, (err) => { console.log(err); });
 
 const server = http.createServer(app);
 server.listen(process.env.NODE_PORT || 3000);

--- a/src/main/app.js
+++ b/src/main/app.js
@@ -1,21 +1,9 @@
 const express = require('express');
-const mongoose = require('mongoose');
 
 const zikResourceRouter = require('./zikresource/zikresource-api');
 
 const app = express();
 
-// TODO : change to use env var
-const connect = mongoose.connect('mongodb://localhost:27017/zikstock',
-    {
-        useNewUrlParser: true,
-        useUnifiedTopology: true,
-        useCreateIndex: true,
-        useFindAndModify: false
-    });
-connect.then(() => {
-    console.log("Connected to MongoDB");
-}, (err) => { console.log(err); });
 
 app.use('/api/zikresources', zikResourceRouter);
 


### PR DESCRIPTION
The DB connection was moved to app.js, but not a good idea because of that, the unit tests ask the DB connection instead of just use the mongodb in memory.